### PR TITLE
Fix timezones on profile page

### DIFF
--- a/src/app/(app)/profile/[slug]/page.tsx
+++ b/src/app/(app)/profile/[slug]/page.tsx
@@ -9,7 +9,8 @@ import {WorkshopHostBadge} from '@/components/workshop-host-badge'
 import {cn} from '@/utils/cn'
 import {EnvelopeIcon, GlobeAltIcon} from '@heroicons/react/20/solid'
 import {allProfiles, allSessions} from 'contentlayer/generated'
-import {addMinutes, format} from 'date-fns'
+import {addMinutes} from 'date-fns'
+import {format, toZonedTime} from 'date-fns-tz'
 import {useMDXComponent} from 'next-contentlayer/hooks'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -129,8 +130,8 @@ export default function AttendeePage({params: {slug}}: {params: {slug: string}})
                       </h3>
                     </div>
                     <div className="shrink-0 text-right leading-tight">
-                      <div>{`${format(new Date(start), 'HH:mm')}`}</div>
-                      <div>{format(addMinutes(new Date(start), duration), 'HH:mm')}</div>
+                      <div>{format(toZonedTime(start, 'Europe/Berlin'), 'HH:mm', {timeZone: 'Europe/Berlin'})}</div>
+                      <div>{format(toZonedTime(addMinutes(start, duration), 'Europe/Berlin'), 'HH:mm', {timeZone: 'Europe/Berlin'})}</div>
                     </div>
                   </div>
                 </Link>


### PR DESCRIPTION
Browsing the app this morning I noticed that the times of sessions on the profile page of a speaker was off by 2 hours and I got curious.
I found the bug and copy-pased the TZ logic from elsewhere in the app codebase.

I cannot reproduce this on my laptop, but here's a screenshot from my phone.

## The session page ✅
![signal-2025-05-28-080727](https://github.com/user-attachments/assets/b2c25f92-db98-4161-b4d4-5f121c412e65)

## The profile page ❌

![signal-2025-05-28-080715](https://github.com/user-attachments/assets/c492966f-2525-4180-9dea-8f4a33bff122)